### PR TITLE
Disable icon front

### DIFF
--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -11,7 +11,7 @@
 // Reset and dependencies
 @import "normalize.less";
 @import "print.less";
-@import "glyphicons.less";
+// @import "glyphicons.less";
 
 // Core CSS
 @import "scaffolding.less";


### PR DESCRIPTION
- The icon font path directory is not correctly resolved by
  lifehack CSS compiler, which cause error in grunt production
