### PR TITLE
Use "bold" font weight for headings

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -67,7 +67,7 @@
 
 //** By default, this inherits from the `<body>`.
 @headings-font-family:    inherit;
-@headings-font-weight:    500;
+@headings-font-weight:    700;
 @headings-line-height:    1.1;
 @headings-color:          inherit;
 


### PR DESCRIPTION
Can reference `bootstrap-3-migration.less` file, we use `bold` for font weight in all headings tags
